### PR TITLE
Don't autogrow after autogrow is disabled

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -582,6 +582,7 @@
             }());
 
             var frame = (function() {
+                var autoGrowTimer;
                 return  {
                     /**
                      * @public
@@ -715,9 +716,10 @@
                         var ival = ($$.isNil(interval)) ? 300 : interval;
                         autog  = ($$.isNil(b)) ? true : b;
                         if (autog === false) {
+                            clearTimeout(autoGrowTimer);
                             return;
                         }
-                        setTimeout(function () {
+                        autoGrowTimer = setTimeout(function () {
                             submodules.frame.resize(client);
                             submodules.frame.autogrow(client, autog);
                         },ival);


### PR DESCRIPTION
Fix autogrow so it can be disabled after being enabled by canceling the
pending timeout to autogrow.
