### PR TITLE
Add support for bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ Currently, we provide Java and Ruby examples, but you can develop in whatever la
 
 	git clone git@github.com:forcedotcom/SalesforceCanvasJavascriptSDK.git
 
+### How to install the SDK (using _bower_)
+
+```shell
+bower install salesforce-canvas-js-sdk
+```
+
+Then add a `<script>` to your `index.html`:
+
+```html
+<script src="/bower_components/salesforce-canvas-js-sdk/js/canvas-all.js">
+```
+
 ### How to use the Canvas JavaScript SDK
 To use this SDK, simply include the canvas-all.js file in your page.
 

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "salesforce-canvas-js-sdk",
+  "version": "31.1.0",
+  "homepage": "https://github.com/forcedotcom/SalesforceCanvasJavascriptSDK",
+  "description": "A JavaScript SDK used to integrate applications with the Force.com Canvas Framework",
+  "main": "./js/canvas-all.js",
+  "keywords": [
+    "salesforce",
+    "salesforce.com",
+    "sfdc",
+    "force.com",
+    "forcedotcom",
+    "canvas"
+  ],
+  "license": "LICENSE.txt",
+  "ignore": [
+    "**/.*"
+  ]
+}


### PR DESCRIPTION
[bower](http://bower.io) is so much better than the currently [recommended](https://github.com/forcedotcom/SalesforceCanvasFrameworkSDK#how-to-clone-the-sdk-repository) way to reference the SDK. This PR adds a `bower.json` file and updates the `README.md` accordingly. 
