### PR TITLE
Using window in the IIFEs instead of this

### DIFF
--- a/js/canvas-all.js
+++ b/js/canvas-all.js
@@ -465,7 +465,7 @@
     global.Sfdc = {}
   }
   global.Sfdc.canvas = canvas
-})(this);
+})(window);
 (function($$) {
   var module = function() {
     function isSecure() {
@@ -762,7 +762,7 @@
     return{post:postMessage, receive:receiveMessage, remove:removeListener}
   }();
   $$.module("Sfdc.canvas.xd", module)
-})(Sfdc.canvas, this);
+})(Sfdc.canvas, window);
 (function($$) {
   var pversion, cversion = "34.0";
   var module = function() {

--- a/js/canvas.js
+++ b/js/canvas.js
@@ -938,4 +938,4 @@
     global.Sfdc.canvas = canvas;
 
 
-}(this));
+}(window));

--- a/js/xd.js
+++ b/js/xd.js
@@ -143,4 +143,4 @@
 
     $$.module('Sfdc.canvas.xd', module);
 
-}(Sfdc.canvas, this));
+}(Sfdc.canvas, window));


### PR DESCRIPTION
Hi,

Currently at the end of the IIFEs around the `xd.js` and `canvas.js` (and in the concatenated `canva-all.js`), you use `this` to refer to the global window object. This, while works okay if you just put the script tag into your html, prevents the code to be used with browserify (and most of the other AMD module loaders), as the `this` will point to the module.exports object.

This won't change how the code works if you include it in a script tag, but will allow your users to use it with AMD module loaders (browserify, webpack, etc).
