### PR TITLE
Prepare for publish to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,23 +1,33 @@
-SalesforceCanvasJavascriptSDK
-=============================
+# SalesforceCanvasJavascriptSDK
 
 A JavaScript SDK used to integrate applications with the Force.com Canvas framework
 
-
-###Introduction
+### Introduction
 
 Force.com Canvas is a mechanism for consuming third-party applications within Salesforce. Its goal is to connect applications at a UI level instead of just an API level. The purpose of this GitHub repository is to provide third-party applications with a JavaScript SDK so you can easily integrate canvas-style applications into Salesforce, while developing in the technology and platform of your choice. 
 
 The best place to get started building canvas applications is the [online developer's guide](http://www.salesforce.com/us/developer/docs/platform_connect/index.htm).
 
-Currently, we provide Java and Ruby examples, but you can develop in whatever language you prefer. Most of the integration with Salesforce is through JavaScript and REST. You can also run and test your application locally from your own host, or from [Heroku](http://www.heroku.com/).  For a quick example of how to create a Java Canvas application, please see the [SalesforceCanvasFrameworkSDK GitHub project](https://github.com/forcedotcom/SalesforceCanvasFrameworkSDK)
+Currently, we provide Java and Ruby examples, but you can develop in whatever language you prefer. Most of the integration with Salesforce is through JavaScript and REST. You can also run and test your application locally from your own host, or from [Heroku](http://www.heroku.com/).  For a quick example of how to create a Java Canvas application, please see the [SalesforceCanvasFrameworkSDK GitHub project](https://github.com/forcedotcom/SalesforceCanvasFrameworkSDK).
 
+### How to install the SDK (using _npm_)
+ 
+    npm install @salesforce/canvas-js-sdk
+ 
+Then add a `<script>` to your `index.html`:
+
+    <script src="node_modules/%40salesforce/canvas-js-sdk/js/canvas-all.js">
+
+Or from React:
+
+    import '@salesforce/canvas-js-sdk';
 
 ### How to clone the SDK repository
 
-	git clone git@github.com:forcedotcom/SalesforceCanvasJavascriptSDK.git
+    git clone git@github.com:forcedotcom/SalesforceCanvasJavascriptSDK.git
 
 ### How to use the Canvas JavaScript SDK
+
 To use this SDK, simply include the canvas-all.js file in your page.
 
 ### Documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@salesforce/canvas-js-sdk",
+  "version": "1.40.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@salesforce/canvas-js-sdk",
+  "version": "1.40.1",
+  "description": "A JavaScript SDK used to integrate applications with the Force.com Canvas framework",
+  "main": "js/canvas-all.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forcedotcom/SalesforceCanvasJavascriptSDK.git"
+  },
+  "keywords": [
+    "salesforce",
+    "canvas"
+  ],
+  "author": "msenn@salesforce.com",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/forcedotcom/SalesforceCanvasJavascriptSDK/issues"
+  },
+  "homepage": "https://github.com/forcedotcom/SalesforceCanvasJavascriptSDK#readme"
+}


### PR DESCRIPTION
Add package.json to describe npm package. Add instructions to README.md for referencing SDK in plain HTML and in React.

Setting initial version to 1.40.1. The minor version means this is version 40 of the API. The patch version means I accidently published and unpublished 1.40.0 onto npmjs.com, and have to update the patch version.